### PR TITLE
Use https for api calls

### DIFF
--- a/Tvarkau Vilnių/MPISP.m
+++ b/Tvarkau Vilnių/MPISP.m
@@ -404,7 +404,7 @@ static NSInteger ERROR_CODE_EMPTY_RESPONSE = 91919111;
         return;
     }
     
-    NSURL *url = [NSURL URLWithString:@"http://www.vilnius.lt/m/m_problems/files/mobile/server.php"];
+    NSURL *url = [NSURL URLWithString:@"https://www.vilnius.lt/m/m_problems/files/mobile/server.php"];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     [request addValue:@"application/json" forHTTPHeaderField:@"Content-type"];
     [request setHTTPMethod:@"POST"];


### PR DESCRIPTION
Without this, all api calls receive this error:

```
The resource could not be loaded because the App Transport Security policy requires the use of a secure connection.
```

Thus throwing out constant "Nera interneto rysio" errors