### PR TITLE
Fix layouts breaking on main screen

### DIFF
--- a/Tvarkau Vilnių/Main.storyboard
+++ b/Tvarkau Vilnių/Main.storyboard
@@ -110,7 +110,7 @@
                                 <rect key="frame" x="22" y="20" width="276" height="168"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="276" id="Ehm-xF-sFx"/>
-                                    <constraint firstAttribute="height" relation="lessThanOrEqual" constant="168" id="fWo-j8-ubS"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="168" id="fWo-j8-ubS"/>
                                 </constraints>
                             </imageView>
                         </subviews>


### PR DESCRIPTION
Changed relation for main image view from lower or equal to to greater than or equal. This way constraints don't break on larger screens

<img width="730" alt="screen shot 2016-01-03 at 23 11 44" src="https://cloud.githubusercontent.com/assets/1474237/12080836/a4404ab2-b270-11e5-8913-7c8577b10c30.png">